### PR TITLE
Function returning the compressed form of a G1 point

### DIFF
--- a/bls/bls_hbls.go
+++ b/bls/bls_hbls.go
@@ -113,6 +113,10 @@ func EqualG2(a *G2Point, b *G2Point) bool {
 	return (*hbls.G2)(a).IsEqual((*hbls.G2)(b))
 }
 
+func ToCompressedG1(p *G1Point) []byte {
+	return hbls.CastToPublicKey((*hbls.G1)(p)).Serialize()
+}
+
 func LinCombG1(numbers []G1Point, factors []Fr) *G1Point {
 	var out G1Point
 	// We're just using unsafe to cast elements that are an alias anyway, no problem.

--- a/bls/bls_kilic.go
+++ b/bls/bls_kilic.go
@@ -111,6 +111,10 @@ func EqualG2(a *G2Point, b *G2Point) bool {
 	return curveG2.Equal((*kbls.PointG2)(a), (*kbls.PointG2)(b))
 }
 
+func ToCompressedG1(p *G1Point) []byte {
+	return curveG1.ToCompressed((*kbls.PointG1)(p))
+}
+
 func LinCombG1(numbers []G1Point, factors []Fr) *G1Point {
 	if len(numbers) != len(factors) {
 		panic("got LinCombG1 numbers/factors length mismatch")

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -1,0 +1,20 @@
+package bls
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPointCompression(t *testing.T) {
+	var x Fr
+	SetFr(&x, "44689111813071777962210527909085028157792767057343609826799812096627770269092")
+	var point G1Point
+	MulG1(&point, &GenG1, &x)
+	got := ToCompressedG1(&point)
+
+	expected := []byte{134, 87, 163, 76, 148, 138, 55, 228, 171, 85, 80, 116, 242, 13, 169, 151, 167, 6, 219, 183, 108, 254, 214, 99, 184, 231, 210, 201, 39, 69, 184, 188, 105, 194, 22, 32, 9, 57, 220, 81, 82, 164, 97, 236, 201, 116, 2, 83}
+
+	if !bytes.Equal(expected, got) {
+		t.Fatalf("Invalid compression result, %v != %x", got, expected)
+	}
+}


### PR DESCRIPTION
This is required for verkle trees, as the hashes are calculated on the compressed form of a commitment.