### PR TITLE
Commit in evaluation form

### DIFF
--- a/das_extension.go
+++ b/das_extension.go
@@ -13,7 +13,7 @@ func (fs *FFTSettings) dASFFTExtension(ab []bls.Fr, domainStride uint64) {
 		var y bls.Fr
 		bls.SubModFr(&y, aHalf0, aHalf1)
 		var tmp bls.Fr
-		bls.MulModFr(&tmp, &y, &fs.expandedRootsOfUnity[domainStride])
+		bls.MulModFr(&tmp, &y, &fs.ExpandedRootsOfUnity[domainStride])
 		bls.AddModFr(&ab[0], &x, &tmp)
 		bls.SubModFr(&ab[1], &x, &tmp)
 		return
@@ -36,7 +36,7 @@ func (fs *FFTSettings) dASFFTExtension(ab []bls.Fr, domainStride uint64) {
 		aHalf1 := &abHalf1s[i]
 		bls.AddModFr(&tmp1, aHalf0, aHalf1)
 		bls.SubModFr(&tmp2, aHalf0, aHalf1)
-		bls.MulModFr(aHalf1, &tmp2, &fs.reverseRootsOfUnity[i*2*domainStride])
+		bls.MulModFr(aHalf1, &tmp2, &fs.ReverseRootsOfUnity[i*2*domainStride])
 		bls.CopyFr(aHalf0, &tmp1)
 	}
 
@@ -57,7 +57,7 @@ func (fs *FFTSettings) dASFFTExtension(ab []bls.Fr, domainStride uint64) {
 		// Note that one hand is from L1, the other R1
 		bls.CopyFr(&x, &abHalf0s[i])
 		bls.CopyFr(&y, &abHalf1s[i])
-		root := &fs.expandedRootsOfUnity[(1+2*i)*domainStride]
+		root := &fs.ExpandedRootsOfUnity[(1+2*i)*domainStride]
 		bls.MulModFr(&yTimesRoot, &y, root)
 		// write outputs in place, avoid unnecessary list allocations
 		bls.AddModFr(&abHalf0s[i], &x, &yTimesRoot)
@@ -69,7 +69,7 @@ func (fs *FFTSettings) dASFFTExtension(ab []bls.Fr, domainStride uint64) {
 // Then computes the values for the odd indices, which combined would make the right half of coefficients zero.
 // Warning: the odd results are written back to the vals slice.
 func (fs *FFTSettings) DASFFTExtension(vals []bls.Fr) {
-	if uint64(len(vals))*2 > fs.maxWidth {
+	if uint64(len(vals))*2 > fs.MaxWidth {
 		panic("domain too small for extending requested values")
 	}
 	fs.dASFFTExtension(vals, 1)

--- a/das_extension_bench_test.go
+++ b/das_extension_bench_test.go
@@ -8,8 +8,8 @@ import (
 
 func benchFFTExtension(scale uint8, b *testing.B) {
 	fs := NewFFTSettings(scale)
-	data := make([]bls.Fr, fs.maxWidth/2, fs.maxWidth/2)
-	for i := uint64(0); i < fs.maxWidth/2; i++ {
+	data := make([]bls.Fr, fs.MaxWidth/2, fs.MaxWidth/2)
+	for i := uint64(0); i < fs.MaxWidth/2; i++ {
 		bls.CopyFr(&data[i], bls.RandomFr())
 	}
 	b.ResetTimer()

--- a/das_extension_test.go
+++ b/das_extension_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestDASFFTExtension(t *testing.T) {
 	fs := NewFFTSettings(4)
-	half := fs.maxWidth / 2
+	half := fs.MaxWidth / 2
 	data := make([]bls.Fr, half, half)
 	for i := uint64(0); i < half; i++ {
 		bls.AsFr(&data[i], i)
@@ -41,14 +41,14 @@ func TestDASFFTExtension(t *testing.T) {
 func TestParametrizedDASFFTExtension(t *testing.T) {
 	testScale := func(seed int64, scale uint8, t *testing.T) {
 		fs := NewFFTSettings(scale)
-		evenData := make([]bls.Fr, fs.maxWidth/2, fs.maxWidth/2)
+		evenData := make([]bls.Fr, fs.MaxWidth/2, fs.MaxWidth/2)
 		rng := rand.New(rand.NewSource(seed))
-		for i := uint64(0); i < fs.maxWidth/2; i++ {
+		for i := uint64(0); i < fs.MaxWidth/2; i++ {
 			bls.AsFr(&evenData[i], rng.Uint64()) // TODO could be a full random F_r instead of uint64
 		}
 		debugFrs("input data", evenData)
 		// we don't want to modify the original input, and the inner function would modify it in-place, so make a copy.
-		oddData := make([]bls.Fr, fs.maxWidth/2, fs.maxWidth/2)
+		oddData := make([]bls.Fr, fs.MaxWidth/2, fs.MaxWidth/2)
 		for i := 0; i < len(oddData); i++ {
 			bls.CopyFr(&oddData[i], &evenData[i])
 		}
@@ -56,8 +56,8 @@ func TestParametrizedDASFFTExtension(t *testing.T) {
 		debugFrs("output data", oddData)
 
 		// reconstruct data
-		data := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-		for i := uint64(0); i < fs.maxWidth; i += 2 {
+		data := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+		for i := uint64(0); i < fs.MaxWidth; i += 2 {
 			bls.CopyFr(&data[i], &evenData[i>>1])
 			bls.CopyFr(&data[i+1], &oddData[i>>1])
 		}
@@ -69,7 +69,7 @@ func TestParametrizedDASFFTExtension(t *testing.T) {
 		}
 		debugFrs("coeffs data", coeffs)
 		// second half of all coefficients should be zero
-		for i := fs.maxWidth / 2; i < fs.maxWidth; i++ {
+		for i := fs.MaxWidth / 2; i < fs.MaxWidth; i++ {
 			if !bls.EqualZero(&coeffs[i]) {
 				t.Errorf("expected zero coefficient on index %d", i)
 			}

--- a/fft.go
+++ b/fft.go
@@ -32,13 +32,13 @@ func expandRootOfUnity(rootOfUnity *bls.Fr) []bls.Fr {
 }
 
 type FFTSettings struct {
-	maxWidth uint64
+	MaxWidth uint64
 	// the generator used to get all roots of unity
-	rootOfUnity *bls.Fr
+	RootOfUnity *bls.Fr
 	// domain, starting and ending with 1 (duplicate!)
-	expandedRootsOfUnity []bls.Fr
+	ExpandedRootsOfUnity []bls.Fr
 	// reverse domain, same as inverse values of domain. Also starting and ending with 1.
-	reverseRootsOfUnity []bls.Fr
+	ReverseRootsOfUnity []bls.Fr
 }
 
 func NewFFTSettings(maxScale uint8) *FFTSettings {
@@ -53,9 +53,9 @@ func NewFFTSettings(maxScale uint8) *FFTSettings {
 	}
 
 	return &FFTSettings{
-		maxWidth:             width,
-		rootOfUnity:          root,
-		expandedRootsOfUnity: rootz,
-		reverseRootsOfUnity:  rootzReverse,
+		MaxWidth:             width,
+		RootOfUnity:          root,
+		ExpandedRootsOfUnity: rootz,
+		ReverseRootsOfUnity:  rootzReverse,
 	}
 }

--- a/fft_fr.go
+++ b/fft_fr.go
@@ -54,8 +54,8 @@ func (fs *FFTSettings) _fft(vals []bls.Fr, valsOffset uint64, valsStride uint64,
 
 func (fs *FFTSettings) FFT(vals []bls.Fr, inv bool) ([]bls.Fr, error) {
 	n := uint64(len(vals))
-	if n > fs.maxWidth {
-		return nil, fmt.Errorf("got %d values but only have %d roots of unity", n, fs.maxWidth)
+	if n > fs.MaxWidth {
+		return nil, fmt.Errorf("got %d values but only have %d roots of unity", n, fs.MaxWidth)
 	}
 	n = nextPowOf2(n)
 	// We make a copy so we can mutate it during the work.
@@ -75,8 +75,8 @@ func (fs *FFTSettings) FFT(vals []bls.Fr, inv bool) ([]bls.Fr, error) {
 
 func (fs *FFTSettings) InplaceFFT(vals []bls.Fr, out []bls.Fr, inv bool) error {
 	n := uint64(len(vals))
-	if n > fs.maxWidth {
-		return fmt.Errorf("got %d values but only have %d roots of unity", n, fs.maxWidth)
+	if n > fs.MaxWidth {
+		return fmt.Errorf("got %d values but only have %d roots of unity", n, fs.MaxWidth)
 	}
 	if !bls.IsPowerOfTwo(n) {
 		return fmt.Errorf("got %d values but not a power of two", n)
@@ -85,8 +85,8 @@ func (fs *FFTSettings) InplaceFFT(vals []bls.Fr, out []bls.Fr, inv bool) error {
 		var invLen bls.Fr
 		bls.AsFr(&invLen, n)
 		bls.InvModFr(&invLen, &invLen)
-		rootz := fs.reverseRootsOfUnity[:fs.maxWidth]
-		stride := fs.maxWidth / n
+		rootz := fs.ReverseRootsOfUnity[:fs.MaxWidth]
+		stride := fs.MaxWidth / n
 
 		fs._fft(vals, 0, 1, rootz, stride, out)
 		var tmp bls.Fr
@@ -96,8 +96,8 @@ func (fs *FFTSettings) InplaceFFT(vals []bls.Fr, out []bls.Fr, inv bool) error {
 		}
 		return nil
 	} else {
-		rootz := fs.expandedRootsOfUnity[:fs.maxWidth]
-		stride := fs.maxWidth / n
+		rootz := fs.ExpandedRootsOfUnity[:fs.MaxWidth]
+		stride := fs.MaxWidth / n
 		// Regular FFT
 		fs._fft(vals, 0, 1, rootz, stride, out)
 		return nil

--- a/fft_fr_bench_test.go
+++ b/fft_fr_bench_test.go
@@ -8,8 +8,8 @@ import (
 
 func benchFFT(scale uint8, b *testing.B) {
 	fs := NewFFTSettings(scale)
-	data := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth; i++ {
+	data := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth; i++ {
 		bls.CopyFr(&data[i], bls.RandomFr())
 	}
 	b.ResetTimer()

--- a/fft_fr_test.go
+++ b/fft_fr_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestFFTRoundtrip(t *testing.T) {
 	fs := NewFFTSettings(4)
-	data := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth; i++ {
+	data := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth; i++ {
 		bls.AsFr(&data[i], i)
 	}
 	coeffs, err := fs.FFT(data, false)
@@ -30,8 +30,8 @@ func TestFFTRoundtrip(t *testing.T) {
 
 func TestInvFFT(t *testing.T) {
 	fs := NewFFTSettings(4)
-	data := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth; i++ {
+	data := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth; i++ {
 		bls.AsFr(&data[i], i)
 	}
 	debugFrs("input data", data)

--- a/fft_g1.go
+++ b/fft_g1.go
@@ -56,8 +56,8 @@ func (fs *FFTSettings) _fftG1(vals []bls.G1Point, valsOffset uint64, valsStride 
 
 func (fs *FFTSettings) FFTG1(vals []bls.G1Point, inv bool) ([]bls.G1Point, error) {
 	n := uint64(len(vals))
-	if n > fs.maxWidth {
-		return nil, fmt.Errorf("got %d values but only have %d roots of unity", n, fs.maxWidth)
+	if n > fs.MaxWidth {
+		return nil, fmt.Errorf("got %d values but only have %d roots of unity", n, fs.MaxWidth)
 	}
 	if !bls.IsPowerOfTwo(n) {
 		return nil, fmt.Errorf("got %d values but not a power of two", n)
@@ -71,8 +71,8 @@ func (fs *FFTSettings) FFTG1(vals []bls.G1Point, inv bool) ([]bls.G1Point, error
 		var invLen bls.Fr
 		bls.AsFr(&invLen, n)
 		bls.InvModFr(&invLen, &invLen)
-		rootz := fs.reverseRootsOfUnity[:fs.maxWidth]
-		stride := fs.maxWidth / n
+		rootz := fs.ReverseRootsOfUnity[:fs.MaxWidth]
+		stride := fs.MaxWidth / n
 
 		out := make([]bls.G1Point, n, n)
 		fs._fftG1(valsCopy, 0, 1, rootz, stride, out)
@@ -84,8 +84,8 @@ func (fs *FFTSettings) FFTG1(vals []bls.G1Point, inv bool) ([]bls.G1Point, error
 		return out, nil
 	} else {
 		out := make([]bls.G1Point, n, n)
-		rootz := fs.expandedRootsOfUnity[:fs.maxWidth]
-		stride := fs.maxWidth / n
+		rootz := fs.ExpandedRootsOfUnity[:fs.MaxWidth]
+		stride := fs.MaxWidth / n
 		// Regular FFT
 		fs._fftG1(valsCopy, 0, 1, rootz, stride, out)
 		return out, nil

--- a/fft_g1_bench_test.go
+++ b/fft_g1_bench_test.go
@@ -10,8 +10,8 @@ import (
 
 func benchFFTG1(scale uint8, b *testing.B) {
 	fs := NewFFTSettings(scale)
-	data := make([]bls.G1Point, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth; i++ {
+	data := make([]bls.G1Point, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth; i++ {
 		var tmpG1 bls.G1Point
 		bls.CopyG1(&tmpG1, &bls.GenG1)
 		bls.MulG1(&data[i], &tmpG1, bls.RandomFr())

--- a/fk20_multi.go
+++ b/fk20_multi.go
@@ -24,9 +24,9 @@ import (
 func (ks *FK20MultiSettings) FK20Multi(polynomial []bls.Fr) []bls.G1Point {
 	n := uint64(len(polynomial))
 	n2 := n * 2
-	if ks.maxWidth < n2 {
-		panic(fmt.Errorf("KZGSettings are set to maxWidth %d but got half polynomial of length %d",
-			ks.maxWidth, n))
+	if ks.MaxWidth < n2 {
+		panic(fmt.Errorf("KZGSettings are set to MaxWidth %d but got half polynomial of length %d",
+			ks.MaxWidth, n))
 	}
 
 	hExtFFT := make([]bls.G1Point, n2, n2)
@@ -56,9 +56,9 @@ func (ks *FK20MultiSettings) FK20Multi(polynomial []bls.Fr) []bls.G1Point {
 // coefficients == 0
 func (ks *FK20MultiSettings) FK20MultiDAOptimized(polynomial []bls.Fr) []bls.G1Point {
 	n2 := uint64(len(polynomial))
-	if ks.maxWidth < n2 {
-		panic(fmt.Errorf("KZGSettings are set to maxWidth %d but got polynomial of length %d",
-			ks.maxWidth, n2))
+	if ks.MaxWidth < n2 {
+		panic(fmt.Errorf("KZGSettings are set to MaxWidth %d but got polynomial of length %d",
+			ks.MaxWidth, n2))
 	}
 	n := n2 / 2
 	for i := n; i < n2; i++ {
@@ -111,7 +111,7 @@ func (ks *FK20MultiSettings) FK20MultiDAOptimized(polynomial []bls.Fr) []bls.G1P
 // and reordering according to reverse bit order
 func (ks *FK20MultiSettings) DAUsingFK20Multi(polynomial []bls.Fr) []bls.G1Point {
 	n := uint64(len(polynomial))
-	if n > ks.maxWidth/2 {
+	if n > ks.MaxWidth/2 {
 		panic("expected poly contents not bigger than half the size of the FK20-multi settings")
 	}
 	if !bls.IsPowerOfTwo(n) {

--- a/fk20_multi_test.go
+++ b/fk20_multi_test.go
@@ -56,20 +56,20 @@ func TestKZGSettings_DAUsingFK20Multi(t *testing.T) {
 	debugFrs("extended_data", extendedData)
 
 	n2 := n * 2
-	domainStride := fk.maxWidth / n2
+	domainStride := fk.MaxWidth / n2
 	for pos := uint64(0); pos < 2*chunkCount; pos++ {
 		domainPos := reverseBitsLimited(uint32(2*chunkCount), uint32(pos))
 		var x bls.Fr
-		bls.CopyFr(&x, &ks.expandedRootsOfUnity[uint64(domainPos)*domainStride])
+		bls.CopyFr(&x, &ks.ExpandedRootsOfUnity[uint64(domainPos)*domainStride])
 		ys := extendedData[chunkLen*pos : chunkLen*(pos+1)]
 		// ys, but constructed by evaluating the polynomial in the sub-domain range
 		ys2 := make([]bls.Fr, chunkLen, chunkLen)
 		// don't recompute the subgroup domain, just select it from the bigger domain by applying a stride
-		stride := ks.maxWidth / chunkLen
+		stride := ks.MaxWidth / chunkLen
 		coset := make([]bls.Fr, chunkLen, chunkLen)
 		for i := uint64(0); i < chunkLen; i++ {
 			var z bls.Fr // a value of the coset list
-			bls.MulModFr(&z, &x, &ks.expandedRootsOfUnity[i*stride])
+			bls.MulModFr(&z, &x, &ks.ExpandedRootsOfUnity[i*stride])
 			bls.CopyFr(&coset[i], &z)
 			bls.EvalPolyAt(&ys2[i], polynomial, &z)
 		}

--- a/fk20_single.go
+++ b/fk20_single.go
@@ -136,10 +136,10 @@ func (fk *FK20SingleSettings) FK20Single(polynomial []bls.Fr) []bls.G1Point {
 // The upper half of the polynomial coefficients is always 0, so we do not need to extend to twice the size
 // for Toeplitz matrix multiplication
 func (fk *FK20SingleSettings) FK20SingleDAOptimized(polynomial []bls.Fr) []bls.G1Point {
-	if uint64(len(polynomial)) > fk.maxWidth {
+	if uint64(len(polynomial)) > fk.MaxWidth {
 		panic(fmt.Errorf(
 			"expected input of length %d (incl half of zeroes) to not exceed precomputed settings length %d",
-			len(polynomial), fk.maxWidth))
+			len(polynomial), fk.MaxWidth))
 	}
 	n2 := uint64(len(polynomial))
 	if !bls.IsPowerOfTwo(n2) {
@@ -174,7 +174,7 @@ func (fk *FK20SingleSettings) FK20SingleDAOptimized(polynomial []bls.Fr) []bls.G
 // and reordering according to reverse bit order
 func (fk *FK20SingleSettings) DAUsingFK20(polynomial []bls.Fr) []bls.G1Point {
 	n := uint64(len(polynomial))
-	if n > fk.maxWidth/2 {
+	if n > fk.MaxWidth/2 {
 		panic("expected poly contents not bigger than half the size of the FK20-single settings")
 	}
 	if !bls.IsPowerOfTwo(n) {

--- a/fk20_single_test.go
+++ b/fk20_single_test.go
@@ -29,7 +29,7 @@ func TestKZGSettings_DAUsingFK20(t *testing.T) {
 	var posFr bls.Fr
 	bls.AsFr(&posFr, pos)
 	var x bls.Fr
-	bls.CopyFr(&x, &ks.expandedRootsOfUnity[pos])
+	bls.CopyFr(&x, &ks.ExpandedRootsOfUnity[pos])
 	t.Log("x:\n", bls.FrStr(&x))
 	var y bls.Fr
 	bls.EvalPolyAt(&y, polynomial, &x)

--- a/integration_test.go
+++ b/integration_test.go
@@ -71,7 +71,7 @@ func TestFullDAS(t *testing.T) {
 	debugFrs("extended data (reordered to original)", extended)
 
 	cosetWidth := uint64(128)
-	fk := NewFK20MultiSettings(ks, ks.maxWidth, cosetWidth)
+	fk := NewFK20MultiSettings(ks, ks.MaxWidth, cosetWidth)
 	// compute proofs for cosets
 	proofs := fk.FK20MultiDAOptimized(extendedAsPoly)
 
@@ -97,11 +97,11 @@ func TestFullDAS(t *testing.T) {
 
 	// verify cosets individually
 	extSize := sampleCount * cosetWidth
-	domainStride := ks.maxWidth / extSize
+	domainStride := ks.MaxWidth / extSize
 	for i, sample := range samples {
 		var x bls.Fr
 		domainPos := uint64(reverseBitsLimited(uint32(sampleCount), uint32(i)))
-		bls.CopyFr(&x, &ks.expandedRootsOfUnity[domainPos*domainStride])
+		bls.CopyFr(&x, &ks.ExpandedRootsOfUnity[domainPos*domainStride])
 		reverseBitOrderFr(sample.sub) // match poly order
 		if !ks.CheckProofMulti(commit, sample.proof, &x, sample.sub) {
 			t.Fatalf("failed to verify proof of sample %d", i)

--- a/kzg.go
+++ b/kzg.go
@@ -15,8 +15,6 @@ type KZGSettings struct {
 	SecretG1 []bls.G1Point
 	// [b.multiply(b.G2, pow(s, i, MODULUS)) for i in range(WIDTH+1)],
 	SecretG2 []bls.G2Point
-
-	SecretG1IFFT []bls.G1Point
 }
 
 func NewKZGSettings(fs *FFTSettings, secretG1 []bls.G1Point, secretG2 []bls.G2Point) *KZGSettings {
@@ -26,16 +24,11 @@ func NewKZGSettings(fs *FFTSettings, secretG1 []bls.G1Point, secretG2 []bls.G2Po
 	if uint64(len(secretG1)) < fs.MaxWidth {
 		panic(fmt.Errorf("expected more values for secrets, MaxWidth: %d, got: %d", fs.MaxWidth, len(secretG1)))
 	}
-	s1IFFT, err := fs.FFTG1(secretG1, true)
-	if err != nil {
-		panic(fmt.Errorf("expected to compute IFFT(secretG1) with sufficient size, but failed: %v", err))
-	}
 
 	ks := &KZGSettings{
-		FFTSettings:  fs,
-		SecretG1:     secretG1,
-		SecretG2:     secretG2,
-		SecretG1IFFT: s1IFFT,
+		FFTSettings: fs,
+		SecretG1:    secretG1,
+		SecretG2:    secretG2,
 	}
 
 	return ks

--- a/kzg_multi_proofs.go
+++ b/kzg_multi_proofs.go
@@ -38,7 +38,7 @@ func (ks *KZGSettings) ComputeProofMulti(poly []bls.Fr, x uint64, n uint64) *bls
 	//}
 
 	// evaluate quotient poly at shared secret, in G1
-	return bls.LinCombG1(ks.secretG1[:len(quotientPolynomial)], quotientPolynomial)
+	return bls.LinCombG1(ks.SecretG1[:len(quotientPolynomial)], quotientPolynomial)
 }
 
 // Check a proof for a KZG commitment for an evaluation f(x w^i) = y_i
@@ -68,10 +68,10 @@ func (ks *KZGSettings) CheckProofMulti(commitment *bls.G1Point, proof *bls.G1Poi
 	bls.MulG2(&xn2, &bls.GenG2, &xPow)
 	// [s^n - x^n]_2
 	var xnMinusYn bls.G2Point
-	bls.SubG2(&xnMinusYn, &ks.secretG2[len(ys)], &xn2)
+	bls.SubG2(&xnMinusYn, &ks.SecretG2[len(ys)], &xn2)
 
 	// [interpolation_polynomial(s)]_1
-	is1 := bls.LinCombG1(ks.secretG1[:len(interpolationPoly)], interpolationPoly)
+	is1 := bls.LinCombG1(ks.SecretG1[:len(interpolationPoly)], interpolationPoly)
 	// [commitment - interpolation_polynomial(s)]_1 = [commit]_1 - [interpolation_polynomial(s)]_1
 	var commitMinusInterpolation bls.G1Point
 	bls.SubG1(&commitMinusInterpolation, commitment, is1)

--- a/kzg_multi_proofs_test.go
+++ b/kzg_multi_proofs_test.go
@@ -12,8 +12,8 @@ func TestKZGSettings_CheckProofMulti(t *testing.T) {
 	fs := NewFFTSettings(4)
 	s1, s2 := GenerateTestingSetup("1927409816240961209460912649124", 16+1)
 	ks := NewKZGSettings(fs, s1, s2)
-	for i := 0; i < len(ks.secretG1); i++ {
-		t.Logf("secret g1 %d: %s", i, bls.StrG1(&ks.secretG1[i]))
+	for i := 0; i < len(ks.SecretG1); i++ {
+		t.Logf("secret g1 %d: %s", i, bls.StrG1(&ks.SecretG1[i]))
 	}
 
 	polynomial := testPoly(1, 2, 3, 4, 7, 7, 7, 7, 13, 13, 13, 13, 13, 13, 13, 13)
@@ -32,8 +32,8 @@ func TestKZGSettings_CheckProofMulti(t *testing.T) {
 	s1, s2 = GenerateTestingSetup("1927409816240961209460912649124", 8+1)
 	ks = NewKZGSettings(NewFFTSettings(cosetScale), s1, s2)
 	for i := 0; i < len(coset); i++ {
-		fmt.Printf("rootz %d: %s\n", i, bls.FrStr(&ks.expandedRootsOfUnity[i]))
-		bls.MulModFr(&coset[i], &xFr, &ks.expandedRootsOfUnity[i])
+		fmt.Printf("rootz %d: %s\n", i, bls.FrStr(&ks.ExpandedRootsOfUnity[i]))
+		bls.MulModFr(&coset[i], &xFr, &ks.ExpandedRootsOfUnity[i])
 		fmt.Printf("coset %d: %s\n", i, bls.FrStr(&coset[i]))
 	}
 	ys := make([]bls.Fr, len(coset), len(coset))

--- a/kzg_single_proofs.go
+++ b/kzg_single_proofs.go
@@ -6,6 +6,12 @@ package kzg
 
 import "github.com/protolambda/go-kzg/bls"
 
+// KZG commitment to polynomial in evaluation form, i.e. eval = FFT(coeffs).
+// The eval length must match the prepared KZG settings width.
+func CommitToEvalPoly(secretG1IFFT []bls.G1Point, eval []bls.Fr) *bls.G1Point {
+	return bls.LinCombG1(secretG1IFFT, eval)
+}
+
 // KZG commitment to polynomial in coefficient form
 func (ks *KZGSettings) CommitToPoly(coeffs []bls.Fr) *bls.G1Point {
 	return bls.LinCombG1(ks.SecretG1[:len(coeffs)], coeffs)

--- a/kzg_single_proofs.go
+++ b/kzg_single_proofs.go
@@ -8,7 +8,7 @@ import "github.com/protolambda/go-kzg/bls"
 
 // KZG commitment to polynomial in coefficient form
 func (ks *KZGSettings) CommitToPoly(coeffs []bls.Fr) *bls.G1Point {
-	return bls.LinCombG1(ks.secretG1[:len(coeffs)], coeffs)
+	return bls.LinCombG1(ks.SecretG1[:len(coeffs)], coeffs)
 }
 
 // KZG commitment to polynomial in coefficient form, unoptimized version
@@ -18,7 +18,7 @@ func (ks *KZGSettings) CommitToPolyUnoptimized(coeffs []bls.Fr) *bls.G1Point {
 	bls.ClearG1(&out)
 	var tmp, tmp2 bls.G1Point
 	for i := 0; i < len(coeffs); i++ {
-		bls.MulG1(&tmp, &ks.secretG1[i], &coeffs[i])
+		bls.MulG1(&tmp, &ks.SecretG1[i], &coeffs[i])
 		bls.AddG1(&tmp2, &out, &tmp)
 		bls.CopyG1(&out, &tmp2)
 	}
@@ -43,7 +43,7 @@ func (ks *KZGSettings) ComputeProofSingle(poly []bls.Fr, x uint64) *bls.G1Point 
 	//}
 
 	// evaluate quotient poly at shared secret, in G1
-	return bls.LinCombG1(ks.secretG1[:len(quotientPolynomial)], quotientPolynomial)
+	return bls.LinCombG1(ks.SecretG1[:len(quotientPolynomial)], quotientPolynomial)
 }
 
 // Check a proof for a KZG commitment for an evaluation f(x) = y
@@ -52,7 +52,7 @@ func (ks *KZGSettings) CheckProofSingle(commitment *bls.G1Point, proof *bls.G1Po
 	var xG2 bls.G2Point
 	bls.MulG2(&xG2, &bls.GenG2, x)
 	var sMinuxX bls.G2Point
-	bls.SubG2(&sMinuxX, &ks.secretG2[1], &xG2)
+	bls.SubG2(&sMinuxX, &ks.SecretG2[1], &xG2)
 	var yG1 bls.G1Point
 	bls.MulG1(&yG1, &bls.GenG1, y)
 	var commitmentMinusY bls.G1Point

--- a/kzg_single_proofs_test.go
+++ b/kzg_single_proofs_test.go
@@ -7,6 +7,28 @@ import (
 	"testing"
 )
 
+func TestKZGSettings_CommitToEvalPoly(t *testing.T) {
+	fs := NewFFTSettings(4)
+	s1, s2 := GenerateTestingSetup("1927409816240961209460912649124", 16+1)
+	ks := NewKZGSettings(fs, s1, s2)
+	polynomial := testPoly(1, 2, 3, 4, 7, 7, 7, 7, 13, 13, 13, 13, 13, 13, 13, 13)
+	evalPoly, err := fs.FFT(polynomial, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretG1IFFT, err := fs.FFTG1(ks.SecretG1[:16], true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	commitmentByCoeffs := ks.CommitToPoly(polynomial)
+	commitmentByEval := CommitToEvalPoly(secretG1IFFT, evalPoly)
+	if !bls.EqualG1(commitmentByEval, commitmentByCoeffs) {
+		t.Fatalf("expected commitments to be equal, but got:\nby eval: %s\nby coeffs: %s",
+			commitmentByEval, commitmentByCoeffs)
+	}
+}
+
 func TestKZGSettings_CheckProofSingle(t *testing.T) {
 	fs := NewFFTSettings(4)
 	s1, s2 := GenerateTestingSetup("1927409816240961209460912649124", 16+1)

--- a/kzg_single_proofs_test.go
+++ b/kzg_single_proofs_test.go
@@ -11,8 +11,8 @@ func TestKZGSettings_CheckProofSingle(t *testing.T) {
 	fs := NewFFTSettings(4)
 	s1, s2 := GenerateTestingSetup("1927409816240961209460912649124", 16+1)
 	ks := NewKZGSettings(fs, s1, s2)
-	for i := 0; i < len(ks.secretG1); i++ {
-		t.Logf("secret g1 %d: %s", i, bls.StrG1(&ks.secretG1[i]))
+	for i := 0; i < len(ks.SecretG1); i++ {
+		t.Logf("secret g1 %d: %s", i, bls.StrG1(&ks.SecretG1[i]))
 	}
 
 	polynomial := testPoly(1, 2, 3, 4, 7, 7, 7, 7, 13, 13, 13, 13, 13, 13, 13, 13)

--- a/legacy_recovery.go
+++ b/legacy_recovery.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (fs *FFTSettings) mulPolysWithFFT(a []bls.Fr, b []bls.Fr, rootsOfUnityStride uint64) []bls.Fr {
-	size := fs.maxWidth / rootsOfUnityStride
+	size := fs.MaxWidth / rootsOfUnityStride
 	aVals := make([]bls.Fr, size, size)
 	bVals := make([]bls.Fr, size, size)
 	for i := 0; i < len(a); i++ {
@@ -23,7 +23,7 @@ func (fs *FFTSettings) mulPolysWithFFT(a []bls.Fr, b []bls.Fr, rootsOfUnityStrid
 	for i := len(b); i < len(bVals); i++ {
 		bVals[i] = bls.ZERO
 	}
-	rootz := fs.expandedRootsOfUnity[:fs.maxWidth]
+	rootz := fs.ExpandedRootsOfUnity[:fs.MaxWidth]
 	// Get FFT of a and b
 	x1 := make([]bls.Fr, len(aVals), len(aVals))
 	fs._fft(aVals, 0, 1, rootz, rootsOfUnityStride, x1)
@@ -37,7 +37,7 @@ func (fs *FFTSettings) mulPolysWithFFT(a []bls.Fr, b []bls.Fr, rootsOfUnityStrid
 		bls.CopyFr(&tmp, &x1[i])
 		bls.MulModFr(&x1[i], &tmp, &x2[i])
 	}
-	revRootz := fs.reverseRootsOfUnity[:fs.maxWidth]
+	revRootz := fs.ReverseRootsOfUnity[:fs.MaxWidth]
 
 	out := make([]bls.Fr, len(x1), len(x1))
 	// compute the FFT of the multiplied values.
@@ -109,7 +109,7 @@ func (fs *FFTSettings) _zPoly(positions []uint64, rootsOfUnityStride uint64) []b
 		var v bls.Fr
 		var tmp bls.Fr
 		for _, pos := range positions {
-			x := &fs.expandedRootsOfUnity[pos*rootsOfUnityStride]
+			x := &fs.ExpandedRootsOfUnity[pos*rootsOfUnityStride]
 			root[i] = bls.ZERO
 			for j := i; j >= 1; j-- {
 				bls.MulModFr(&v, &root[j-1], x)
@@ -130,7 +130,7 @@ func (fs *FFTSettings) _zPoly(positions []uint64, rootsOfUnityStride uint64) []b
 	evenPositions, oddPositions := inefficientOddEvenDiv2(positions)
 	left := fs._zPoly(evenPositions, rootsOfUnityStride<<1)
 	right := fs._zPoly(oddPositions, rootsOfUnityStride<<1)
-	invRoot := &fs.reverseRootsOfUnity[rootsOfUnityStride]
+	invRoot := &fs.ReverseRootsOfUnity[rootsOfUnityStride]
 	// Offset the result for the odd indices, and combine the two
 	out := fs.mulPolysWithFFT(left, pOfKX(right, invRoot), rootsOfUnityStride)
 	// Deal with the special case where mul_polys returns zero
@@ -169,7 +169,7 @@ func (fs *FFTSettings) ErasureCodeRecover(vals []*bls.Fr) ([]bls.Fr, error) {
 		}
 	}
 	// TODO: handle len(positions)==0 case
-	z := fs._zPoly(positions, fs.maxWidth/uint64(len(vals)))
+	z := fs._zPoly(positions, fs.MaxWidth/uint64(len(vals)))
 	//debugFrs("z", z)
 	zVals, err := fs.FFT(z, false)
 	if err != nil {

--- a/legacy_recovery_test.go
+++ b/legacy_recovery_test.go
@@ -10,11 +10,11 @@ import (
 func TestErasureCodeRecoverSimple(t *testing.T) {
 	// Create some random data, with padding...
 	fs := NewFFTSettings(5)
-	poly := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth/2; i++ {
+	poly := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth/2; i++ {
 		bls.AsFr(&poly[i], i)
 	}
-	for i := fs.maxWidth / 2; i < fs.maxWidth; i++ {
+	for i := fs.MaxWidth / 2; i < fs.MaxWidth; i++ {
 		poly[i] = bls.ZERO
 	}
 	debugFrs("poly", poly)
@@ -26,9 +26,9 @@ func TestErasureCodeRecoverSimple(t *testing.T) {
 	debugFrs("data", data)
 
 	// copy over the 2nd half, leave the first half as nils
-	subset := make([]*bls.Fr, fs.maxWidth, fs.maxWidth)
-	half := fs.maxWidth / 2
-	for i := half; i < fs.maxWidth; i++ {
+	subset := make([]*bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	half := fs.MaxWidth / 2
+	for i := half; i < fs.MaxWidth; i++ {
 		subset[i] = &data[i]
 	}
 
@@ -54,7 +54,7 @@ func TestErasureCodeRecoverSimple(t *testing.T) {
 			t.Errorf("coeff at index %d got %s but expected %s", i, bls.FrStr(got), bls.FrStr(&poly[i]))
 		}
 	}
-	for i := half; i < fs.maxWidth; i++ {
+	for i := half; i < fs.MaxWidth; i++ {
 		if got := &back[i]; !bls.EqualZero(got) {
 			t.Errorf("expected zero padding in index %d", i)
 		}
@@ -64,11 +64,11 @@ func TestErasureCodeRecoverSimple(t *testing.T) {
 func TestErasureCodeRecover(t *testing.T) {
 	// Create some random poly, with padding so we get redundant data
 	fs := NewFFTSettings(7)
-	poly := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth/2; i++ {
+	poly := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth/2; i++ {
 		bls.AsFr(&poly[i], i)
 	}
-	for i := fs.maxWidth / 2; i < fs.maxWidth; i++ {
+	for i := fs.MaxWidth / 2; i < fs.MaxWidth; i++ {
 		poly[i] = bls.ZERO
 	}
 	debugFrs("poly", poly)
@@ -81,13 +81,13 @@ func TestErasureCodeRecover(t *testing.T) {
 
 	// Util to pick a random subnet of the values
 	randomSubset := func(known uint64, rngSeed uint64) []*bls.Fr {
-		withMissingValues := make([]*bls.Fr, fs.maxWidth, fs.maxWidth)
+		withMissingValues := make([]*bls.Fr, fs.MaxWidth, fs.MaxWidth)
 		for i := range data {
 			withMissingValues[i] = &data[i]
 		}
 		rng := rand.New(rand.NewSource(int64(rngSeed)))
-		missing := fs.maxWidth - known
-		pruned := rng.Perm(int(fs.maxWidth))[:missing]
+		missing := fs.MaxWidth - known
+		pruned := rng.Perm(int(fs.MaxWidth))[:missing]
 		for _, i := range pruned {
 			withMissingValues[i] = nil
 		}
@@ -97,7 +97,7 @@ func TestErasureCodeRecover(t *testing.T) {
 	// Try different amounts of known indices, and try it in multiple random ways
 	var lastKnown uint64 = 0
 	for knownRatio := 0.7; knownRatio < 1.0; knownRatio += 0.05 {
-		known := uint64(float64(fs.maxWidth) * knownRatio)
+		known := uint64(float64(fs.MaxWidth) * knownRatio)
 		if known == lastKnown {
 			continue
 		}
@@ -129,7 +129,7 @@ func TestErasureCodeRecover(t *testing.T) {
 						t.Errorf("coeff at index %d got %s but expected %s", i, bls.FrStr(got), bls.FrStr(&poly[i]))
 					}
 				}
-				for i := half; i < fs.maxWidth; i++ {
+				for i := half; i < fs.MaxWidth; i++ {
 					if got := &back[i]; !bls.EqualZero(got) {
 						t.Errorf("expected zero padding in index %d", i)
 					}

--- a/recover_from_samples_bench_test.go
+++ b/recover_from_samples_bench_test.go
@@ -9,13 +9,13 @@ import (
 
 func benchRecoverPolyFromSamples(scale uint8, seed int64, b *testing.B) {
 	fs := NewFFTSettings(scale)
-	poly := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth/2; i++ {
+	poly := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth/2; i++ {
 		bls.AsFr(&poly[i], i)
 	}
 	rng := rand.New(rand.NewSource(seed))
 	data, _ := fs.FFT(poly, false)
-	samples := make([]*bls.Fr, fs.maxWidth, fs.maxWidth)
+	samples := make([]*bls.Fr, fs.MaxWidth, fs.MaxWidth)
 	for i := 0; i < len(data); i++ {
 		samples[i] = &data[i]
 	}

--- a/recover_from_samples_test.go
+++ b/recover_from_samples_test.go
@@ -10,11 +10,11 @@ import (
 func TestFFTSettings_RecoverPolyFromSamples_Simple(t *testing.T) {
 	// Create some random data, with padding...
 	fs := NewFFTSettings(2)
-	poly := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth/2; i++ {
+	poly := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth/2; i++ {
 		bls.AsFr(&poly[i], i)
 	}
-	for i := fs.maxWidth / 2; i < fs.maxWidth; i++ {
+	for i := fs.MaxWidth / 2; i < fs.MaxWidth; i++ {
 		poly[i] = bls.ZERO
 	}
 	debugFrs("poly", poly)
@@ -25,7 +25,7 @@ func TestFFTSettings_RecoverPolyFromSamples_Simple(t *testing.T) {
 	}
 	debugFrs("data", data)
 
-	subset := make([]*bls.Fr, fs.maxWidth, fs.maxWidth)
+	subset := make([]*bls.Fr, fs.MaxWidth, fs.MaxWidth)
 	subset[0] = &data[0]
 	subset[3] = &data[3]
 
@@ -46,12 +46,12 @@ func TestFFTSettings_RecoverPolyFromSamples_Simple(t *testing.T) {
 		t.Fatal(err)
 	}
 	debugFrs("back", back)
-	for i := uint64(0); i < fs.maxWidth/2; i++ {
+	for i := uint64(0); i < fs.MaxWidth/2; i++ {
 		if got := &back[i]; !bls.EqualFr(got, &poly[i]) {
 			t.Errorf("coeff at index %d got %s but expected %s", i, bls.FrStr(got), bls.FrStr(&poly[i]))
 		}
 	}
-	for i := fs.maxWidth / 2; i < fs.maxWidth; i++ {
+	for i := fs.MaxWidth / 2; i < fs.MaxWidth; i++ {
 		if got := &back[i]; !bls.EqualZero(got) {
 			t.Errorf("expected zero padding in index %d", i)
 		}
@@ -61,11 +61,11 @@ func TestFFTSettings_RecoverPolyFromSamples_Simple(t *testing.T) {
 func TestFFTSettings_RecoverPolyFromSamples(t *testing.T) {
 	// Create some random poly, with padding so we get redundant data
 	fs := NewFFTSettings(10)
-	poly := make([]bls.Fr, fs.maxWidth, fs.maxWidth)
-	for i := uint64(0); i < fs.maxWidth/2; i++ {
+	poly := make([]bls.Fr, fs.MaxWidth, fs.MaxWidth)
+	for i := uint64(0); i < fs.MaxWidth/2; i++ {
 		bls.AsFr(&poly[i], i)
 	}
-	for i := fs.maxWidth / 2; i < fs.maxWidth; i++ {
+	for i := fs.MaxWidth / 2; i < fs.MaxWidth; i++ {
 		poly[i] = bls.ZERO
 	}
 	debugFrs("poly", poly)
@@ -78,13 +78,13 @@ func TestFFTSettings_RecoverPolyFromSamples(t *testing.T) {
 
 	// Util to pick a random subnet of the values
 	randomSubset := func(known uint64, rngSeed uint64) []*bls.Fr {
-		withMissingValues := make([]*bls.Fr, fs.maxWidth, fs.maxWidth)
+		withMissingValues := make([]*bls.Fr, fs.MaxWidth, fs.MaxWidth)
 		for i := range data {
 			withMissingValues[i] = &data[i]
 		}
 		rng := rand.New(rand.NewSource(int64(rngSeed)))
-		missing := fs.maxWidth - known
-		pruned := rng.Perm(int(fs.maxWidth))[:missing]
+		missing := fs.MaxWidth - known
+		pruned := rng.Perm(int(fs.MaxWidth))[:missing]
 		for _, i := range pruned {
 			withMissingValues[i] = nil
 		}
@@ -94,7 +94,7 @@ func TestFFTSettings_RecoverPolyFromSamples(t *testing.T) {
 	// Try different amounts of known indices, and try it in multiple random ways
 	var lastKnown uint64 = 0
 	for knownRatio := 0.7; knownRatio < 1.0; knownRatio += 0.05 {
-		known := uint64(float64(fs.maxWidth) * knownRatio)
+		known := uint64(float64(fs.MaxWidth) * knownRatio)
 		if known == lastKnown {
 			continue
 		}
@@ -126,7 +126,7 @@ func TestFFTSettings_RecoverPolyFromSamples(t *testing.T) {
 						t.Errorf("coeff at index %d got %s but expected %s", i, bls.FrStr(got), bls.FrStr(&poly[i]))
 					}
 				}
-				for i := half; i < fs.maxWidth; i++ {
+				for i := half; i < fs.MaxWidth; i++ {
 					if got := &back[i]; !bls.EqualZero(got) {
 						t.Errorf("expected zero padding in index %d", i)
 					}

--- a/zero_poly.go
+++ b/zero_poly.go
@@ -25,7 +25,7 @@ func (fs *FFTSettings) makeZeroPolyMulLeaf(dst []bls.Fr, indices []uint64, domai
 	bls.CopyFr(&dst[len(indices)], &bls.ONE)
 	var negDi bls.Fr
 	for i, v := range indices {
-		bls.SubModFr(&negDi, &bls.ZERO, &fs.expandedRootsOfUnity[v*domainStride])
+		bls.SubModFr(&negDi, &bls.ZERO, &fs.ExpandedRootsOfUnity[v*domainStride])
 		bls.CopyFr(&dst[i], &negDi)
 		if i > 0 {
 			bls.AddModFr(&dst[i], &dst[i], &dst[i-1])
@@ -88,13 +88,13 @@ func (fs *FFTSettings) ZeroPolyViaMultiplication(missingIndices []uint64, length
 	if len(missingIndices) == 0 {
 		return make([]bls.Fr, length, length), make([]bls.Fr, length, length)
 	}
-	if length > fs.maxWidth {
+	if length > fs.MaxWidth {
 		panic("too many ")
 	}
 	if !bls.IsPowerOfTwo(length) {
 		panic("length not a power of two")
 	}
-	domainStride := fs.maxWidth / length
+	domainStride := fs.MaxWidth / length
 	// just under a power of two, since the leaf gets 1 bigger after building a poly for it
 	perLeafPoly := uint64(64)
 	perLeaf := perLeafPoly - 1

--- a/zero_poly_bench_test.go
+++ b/zero_poly_bench_test.go
@@ -8,7 +8,7 @@ import (
 
 func benchZeroPoly(scale uint8, seed int64, b *testing.B) {
 	fs := NewFFTSettings(scale)
-	missing := make([]uint64, fs.maxWidth, fs.maxWidth)
+	missing := make([]uint64, fs.MaxWidth, fs.MaxWidth)
 	for i := uint64(0); i < uint64(len(missing)); i++ {
 		missing[i] = i
 	}
@@ -21,7 +21,7 @@ func benchZeroPoly(scale uint8, seed int64, b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		zeroEval, zeroPoly := fs.ZeroPolyViaMultiplication(missing, fs.maxWidth)
+		zeroEval, zeroPoly := fs.ZeroPolyViaMultiplication(missing, fs.MaxWidth)
 		if len(zeroEval) != len(zeroPoly) {
 			panic("sanity check failed, length mismatch")
 		}

--- a/zero_poly_test.go
+++ b/zero_poly_test.go
@@ -109,7 +109,7 @@ func testReduceLeaves(scale uint8, missingRatio float64, seed int64, t *testing.
 	var fromDirect []bls.Fr
 	{
 		dst := make([]bls.Fr, missingCount+1, missingCount+1)
-		fs.makeZeroPolyMulLeaf(dst, missing, fs.maxWidth/pointCount)
+		fs.makeZeroPolyMulLeaf(dst, missing, fs.MaxWidth/pointCount)
 		fromDirect = dst
 	}
 
@@ -198,7 +198,7 @@ func testZeroPoly(t *testing.T, scale uint8, seed int64) {
 
 	rng := rand.New(rand.NewSource(seed))
 
-	exists := make([]bool, fs.maxWidth, fs.maxWidth)
+	exists := make([]bool, fs.MaxWidth, fs.MaxWidth)
 	var missingIndices []uint64
 	missingStr := ""
 	for i := 0; i < len(exists); i++ {
@@ -219,7 +219,7 @@ func testZeroPoly(t *testing.T, scale uint8, seed int64) {
 	for i, v := range exists {
 		if !v {
 			var at bls.Fr
-			bls.CopyFr(&at, &fs.expandedRootsOfUnity[i])
+			bls.CopyFr(&at, &fs.ExpandedRootsOfUnity[i])
 			var out bls.Fr
 			bls.EvalPolyAt(&out, zeroPoly, &at)
 			if !bls.EqualZero(&out) {


### PR DESCRIPTION
To guide library users how to compute the commitment without computing the coefficients of the poly: add a `CommitToEvalPoly(secretG1IFFT []bls.G1Point, eval []bls.Fr)`  function. The roots of unity / secret setup in the settings are all exposed now too.

Example:
```go
// For illustration: the evalPoly (or "ys")
coeffs := 16 Fr values ...
evalPoly := fs.FFT(coeffs, false)

secretG1IFFT, err := fs.FFTG1(ks.SecretG1[:16], true)  // the setup may be larger, slice out the first N values.
commitment := CommitToEvalPoly(secretG1IFFT, evalPoly)
```

