### PR TITLE
BLST support

### DIFF
--- a/bls/bignum_blst.go
+++ b/bls/bignum_blst.go
@@ -5,6 +5,7 @@ package bls
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	blst "github.com/supranational/blst/bindings/go"
 	"math/big"
 )
@@ -60,7 +61,7 @@ func CopyFr(dst *Fr, v *Fr) {
 
 func AsFr(dst *Fr, i uint64) {
 	var data [32]byte
-	binary.BigEndian.PutUint64(data[:8], i)
+	binary.BigEndian.PutUint64(data[24:32], i)
 	var tmp blst.Scalar
 	tmp.FromBEndian(data[:])
 	(*blst.Fr)(dst).FromScalar(&tmp)
@@ -111,7 +112,11 @@ func RandomFr() *Fr {
 }
 
 func SubModFr(dst *Fr, a, b *Fr) {
+	fmt.Printf("dst pre: %s\n", dst)
+	fmt.Printf("a pre: %s\n", a)
+	fmt.Printf("b pre: %s\n", b)
 	(*blst.Fr)(dst).Sub((*blst.Fr)(a), (*blst.Fr)(b))
+	fmt.Printf("dst: %s\n", dst)
 }
 
 func AddModFr(dst *Fr, a, b *Fr) {

--- a/bls/bignum_blst.go
+++ b/bls/bignum_blst.go
@@ -1,0 +1,144 @@
+// +build bignum_blst
+
+package bls
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	blst "github.com/supranational/blst/bindings/go"
+	"math/big"
+)
+
+var _modulus big.Int
+
+var oneScalar, zeroScalar blst.Scalar
+
+func init() {
+	_modulus.SetString("52435875175126190479447740508185965837690552500527637822603658699938581184513", 10)
+	zeroLE := [32]byte{}
+	zeroScalar.FromLEndian(zeroLE[:])
+	oneLE := [32]byte{0: 1}
+	oneScalar.FromLEndian(oneLE[:])
+	initGlobals()
+	ClearG1(&ZERO_G1)
+	initG1G2()
+}
+
+type Fr blst.Fr
+
+func SetFr(dst *Fr, v string) {
+	var bv big.Int
+	bv.SetString(v, 10)
+	var sc blst.Scalar
+	sc.FromBEndian(bv.Bytes())
+	(*blst.Fr)(dst).FromScalar(&sc)
+}
+
+// FrFrom32 mutates the fr num. The value v is little-endian 32-bytes.
+// Returns false, without modifying dst, if the value is out of range.
+func FrFrom32(dst *Fr, v [32]byte) (ok bool) {
+	if !ValidFr(v) {
+		return false
+	}
+	var tmp blst.Scalar
+	tmp.FromLEndian(v[:])
+	(*blst.Fr)(dst).FromScalar(&tmp)
+	return true
+}
+
+// FrTo32 serializes a fr number to 32 bytes. Encoded little-endian.
+func FrTo32(src *Fr) (v [32]byte) {
+	var tmp blst.Scalar
+	tmp.FromFr((*blst.Fr)(src))
+	copy(v[:], tmp.ToLEndian())
+	return
+}
+
+func CopyFr(dst *Fr, v *Fr) {
+	*dst = *v
+}
+
+func AsFr(dst *Fr, i uint64) {
+	var data [32]byte
+	binary.BigEndian.PutUint64(data[:8], i)
+	var tmp blst.Scalar
+	tmp.FromBEndian(data[:])
+	(*blst.Fr)(dst).FromScalar(&tmp)
+}
+
+func FrStr(b *Fr) string {
+	if b == nil {
+		return "<nil>"
+	}
+	var tmp blst.Scalar
+	tmp.FromFr((*blst.Fr)(b))
+	var bv big.Int
+	bv.SetBytes(tmp.ToBEndian())
+	return bv.String()
+}
+
+// TODO: would direct memory comparison work here?
+
+func EqualOne(v *Fr) bool {
+	var tmp blst.Scalar
+	tmp.FromFr((*blst.Fr)(v))
+	return tmp.Equals(&oneScalar)
+}
+
+func EqualZero(v *Fr) bool {
+	var tmp blst.Scalar
+	tmp.FromFr((*blst.Fr)(v))
+	return tmp.Equals(&zeroScalar)
+}
+
+func EqualFr(a *Fr, b *Fr) bool {
+	var aSc, bSc blst.Scalar
+	aSc.FromFr((*blst.Fr)(a))
+	bSc.FromFr((*blst.Fr)(b))
+	return aSc.Equals(&bSc)
+}
+
+func RandomFr() *Fr {
+	v, err := rand.Int(rand.Reader, &_modulus)
+	if err != nil {
+		panic(err)
+	}
+	var tmp blst.Scalar
+	tmp.FromBEndian(v.Bytes())
+	var out blst.Fr
+	out.FromScalar(&tmp)
+	return (*Fr)(&out)
+}
+
+func SubModFr(dst *Fr, a, b *Fr) {
+	(*blst.Fr)(dst).Sub((*blst.Fr)(a), (*blst.Fr)(b))
+}
+
+func AddModFr(dst *Fr, a, b *Fr) {
+	var tmp blst.Fr
+	tmp.Add((*blst.Fr)(a), (*blst.Fr)(b))
+	*dst = (Fr)(tmp)
+}
+
+func DivModFr(dst *Fr, a, b *Fr) {
+	var tmp blst.Fr
+	tmp.EuclInverse((*blst.Fr)(b))
+	(*blst.Fr)(dst).Mul(&tmp, (*blst.Fr)(a))
+}
+
+func MulModFr(dst *Fr, a, b *Fr) {
+	(*blst.Fr)(dst).Mul((*blst.Fr)(a), (*blst.Fr)(b))
+}
+
+func InvModFr(dst *Fr, v *Fr) {
+	(*blst.Fr)(dst).EuclInverse((*blst.Fr)(v))
+}
+
+//func SqrModFr(dst *Fr, v *Fr) {
+//	dst.Sqr(v)
+//}
+
+func EvalPolyAt(dst *Fr, p []Fr, x *Fr) {
+	// TODO: BLST BLS has no optimized evaluation function
+	EvalPolyAtUnoptimized(dst, p, x)
+}

--- a/bls/bignum_hbls.go
+++ b/bls/bignum_hbls.go
@@ -1,4 +1,4 @@
-// +build !bignum_pure,!bignum_hol256,!bignum_kilic
+// +build !bignum_pure,!bignum_hol256,!bignum_kilic,!bignum_blst
 
 package bls
 

--- a/bls/bignum_test.go
+++ b/bls/bignum_test.go
@@ -93,6 +93,7 @@ func TestValidFr(t *testing.T) {
 	if !ValidFr(data) {
 		t.Fatal("expected mod-1 to be valid")
 	}
+	t.Logf("data: %x", data[:])
 	var tmp [32]byte
 	for i := 0; i < 32; i++ {
 		if data[i] == 0xff {
@@ -101,7 +102,7 @@ func TestValidFr(t *testing.T) {
 		tmp = data
 		tmp[i] += 1
 		if ValidFr(tmp) {
-			t.Fatal("expected anything larger than mod-1 to be invalid")
+			t.Fatalf("expected anything larger than mod-1 to be invalid, failed at byte %d", i)
 		}
 	}
 	v := RandomFr()

--- a/bls/bignum_test.go
+++ b/bls/bignum_test.go
@@ -19,7 +19,7 @@ func TestInplaceAdd(t *testing.T) {
 			CopyFr(&a, aVal)
 			CopyFr(&b, bVal)
 			if !fn(&a, &b) {
-				t.Error("fail")
+				t.Errorf("fail: a: %s, b: %s, 2a: %s", &a, &b, twoA)
 			}
 		})
 	}

--- a/bls/bls_blst.go
+++ b/bls/bls_blst.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 )
 
+// TODO duplicate
 var ZERO_G1 G1Point
 
 var GenG1 G1Point
@@ -18,11 +19,10 @@ var ZeroG1 G1Point
 var ZeroG2 G2Point
 
 func initG1G2() {
-	// TODO
-	//GenG1 = G1Point(*curveG1.One())
-	//GenG2 = G2Point(*curveG2.One())
-	//ZeroG1 = G1Point(*curveG1.Zero())
-	//ZeroG2 = G2Point(*curveG2.Zero())
+	GenG1 = *(*G1Point)(blst.GenP1())
+	GenG2 = *(*G2Point)(blst.GenP2())
+
+	// The ZERO_G1, ZeroG1 and ZeroG2 can be left as-is to make them zero.
 }
 
 type G1Point blst.P1
@@ -115,6 +115,10 @@ func EqualG2(a *G2Point, b *G2Point) bool {
 
 func ToCompressedG1(p *G1Point) []byte {
 	return (*blst.P1)(p).Compress()
+}
+
+func ToCompressedG2(p *G2Point) []byte {
+	return (*blst.P2)(p).Compress()
 }
 
 func LinCombG1(numbers []G1Point, factors []Fr) *G1Point {

--- a/bls/bls_blst.go
+++ b/bls/bls_blst.go
@@ -1,0 +1,142 @@
+// +build bignum_blst
+
+package bls
+
+import (
+	"fmt"
+	blst "github.com/supranational/blst/bindings/go"
+	"math/big"
+	"strings"
+)
+
+var ZERO_G1 G1Point
+
+var GenG1 G1Point
+var GenG2 G2Point
+
+var ZeroG1 G1Point
+var ZeroG2 G2Point
+
+func initG1G2() {
+	// TODO
+	//GenG1 = G1Point(*curveG1.One())
+	//GenG2 = G2Point(*curveG2.One())
+	//ZeroG1 = G1Point(*curveG1.Zero())
+	//ZeroG2 = G2Point(*curveG2.Zero())
+}
+
+type G1Point blst.P1
+
+// zeroes the point (like herumi BLS does with theirs). This is not co-factor clearing.
+func ClearG1(x *G1Point) {
+	*x = ZeroG1
+}
+
+func CopyG1(dst *G1Point, v *G1Point) {
+	*dst = *v
+}
+
+func MulG1(dst *G1Point, a *G1Point, b *Fr) {
+	var tmp blst.Scalar
+	tmp.FromFr((*blst.Fr)(b))
+	// TODO: not always 255 bits? BLST has constant-time multiplication here, not fast anyway
+	(*blst.P1)(dst).Mult((*blst.P1)(a), &tmp, 255)
+}
+
+func AddG1(dst *G1Point, a *G1Point, b *G1Point) {
+	(*blst.P1)(dst).Add((*blst.P1)(a), (*blst.P1)(b))
+}
+
+func SubG1(dst *G1Point, a *G1Point, b *G1Point) {
+	tmp := *(*blst.P1)(b)
+	tmp.Negative()
+	(*blst.P1)(dst).Add((*blst.P1)(a), &tmp)
+}
+
+func StrG1(v *G1Point) string {
+	data := (*blst.P1)(v).Serialize()
+	var a, b big.Int
+	a.SetBytes(data[:48])
+	b.SetBytes(data[48:])
+	return a.String() + "\n" + b.String()
+}
+
+func NegG1(dst *G1Point) {
+	(*blst.P1)(dst).Negative()
+}
+
+type G2Point blst.P2
+
+// zeroes the point (like herumi BLS does with theirs). This is not co-factor clearing.
+func ClearG2(x *G2Point) {
+	*x = ZeroG2
+}
+
+func CopyG2(dst *G2Point, v *G2Point) {
+	*dst = *v
+}
+
+func MulG2(dst *G2Point, a *G2Point, b *Fr) {
+	var tmp blst.Scalar
+	tmp.FromFr((*blst.Fr)(b))
+	// TODO: not always 255 bits? BLST has constant-time multiplication here, not fast anyway
+	(*blst.P2)(dst).Mult((*blst.P2)(a), &tmp, 255)
+}
+
+func AddG2(dst *G2Point, a *G2Point, b *G2Point) {
+	(*blst.P2)(dst).Add((*blst.P2)(a), (*blst.P2)(b))
+}
+
+func SubG2(dst *G2Point, a *G2Point, b *G2Point) {
+	tmp := *(*blst.P2)(b)
+	tmp.Negative()
+	(*blst.P2)(dst).Add((*blst.P2)(a), &tmp)
+}
+
+func NegG2(dst *G2Point) {
+	(*blst.P2)(dst).Negative()
+}
+
+func StrG2(v *G2Point) string {
+	data := (*blst.P2)(v).Serialize()
+	var a, b big.Int
+	a.SetBytes(data[:96])
+	b.SetBytes(data[96:])
+	return a.String() + "\n" + b.String()
+}
+
+func EqualG1(a *G1Point, b *G1Point) bool {
+	return (*blst.P1)(a).Equals((*blst.P1)(b))
+}
+
+func EqualG2(a *G2Point, b *G2Point) bool {
+	return (*blst.P2)(a).Equals((*blst.P2)(b))
+}
+
+func ToCompressedG1(p *G1Point) []byte {
+	return (*blst.P1)(p).Compress()
+}
+
+func LinCombG1(numbers []G1Point, factors []Fr) *G1Point {
+	var tmp G1Point
+	var out G1Point
+	CopyG1(&out, &ZERO_G1)
+	for i := 0; i < len(numbers); i++ {
+		MulG1(&tmp, &numbers[i], &factors[i])
+		AddG1(&out, &out, &tmp)
+	}
+	return &out
+}
+
+// e(a1^(-1), a2) * e(b1,  b2) = 1_T
+func PairingsVerify(a1 *G1Point, a2 *G2Point, b1 *G1Point, b2 *G2Point) bool {
+	return blst.PairingsVerify((*blst.P1)(a1), (*blst.P2)(a2), (*blst.P1)(b1), (*blst.P2)(b2))
+}
+
+func DebugG1s(msg string, values []G1Point) {
+	var out strings.Builder
+	for i := range values {
+		out.WriteString(fmt.Sprintf("%s %d: %s\n", msg, i, StrG1(&values[i])))
+	}
+	fmt.Println(out.String())
+}

--- a/bls/bls_hbls.go
+++ b/bls/bls_hbls.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 )
 
+// TODO duplicate
 var ZERO_G1 G1Point
 
 var GenG1 G1Point
@@ -114,6 +115,10 @@ func EqualG2(a *G2Point, b *G2Point) bool {
 
 func ToCompressedG1(p *G1Point) []byte {
 	return hbls.CastToPublicKey((*hbls.G1)(p)).Serialize()
+}
+
+func ToCompressedG2(p *G2Point) []byte {
+	return hbls.CastToSign((*hbls.G2)(p)).Serialize()
 }
 
 func LinCombG1(numbers []G1Point, factors []Fr) *G1Point {

--- a/bls/bls_hbls.go
+++ b/bls/bls_hbls.go
@@ -1,4 +1,4 @@
-// +build !bignum_pure,!bignum_hol256,!bignum_kilic
+// +build !bignum_pure,!bignum_hol256,!bignum_kilic,!bignum_blst
 
 package bls
 
@@ -42,7 +42,6 @@ func initG1G2() {
 	ZeroG2.Z.D[1].SetInt64(0)
 }
 
-// TODO types file, swap BLS with build args
 type G1Point hbls.G1
 
 func ClearG1(x *G1Point) {

--- a/bls/bls_kilic.go
+++ b/bls/bls_kilic.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 )
 
+// TODO duplicate
 var ZERO_G1 G1Point
 
 var curveG1 kbls.G1
@@ -115,6 +116,10 @@ func EqualG2(a *G2Point, b *G2Point) bool {
 
 func ToCompressedG1(p *G1Point) []byte {
 	return curveG1.ToCompressed((*kbls.PointG1)(p))
+}
+
+func ToCompressedG2(p *G2Point) []byte {
+	return curveG2.ToCompressed((*kbls.PointG2)(p))
 }
 
 func LinCombG1(numbers []G1Point, factors []Fr) *G1Point {

--- a/bls/bls_kilic.go
+++ b/bls/bls_kilic.go
@@ -20,7 +20,6 @@ var GenG2 G2Point
 var ZeroG1 G1Point
 var ZeroG2 G2Point
 
-// Herumi BLS doesn't offer these points to us, so we have to work around it by declaring them ourselves.
 func initG1G2() {
 	curveG1 = *kbls.NewG1()
 	curveG2 = *kbls.NewG2()
@@ -30,7 +29,6 @@ func initG1G2() {
 	ZeroG2 = G2Point(*curveG2.Zero())
 }
 
-// TODO types file, swap BLS with build args
 type G1Point kbls.PointG1
 
 // zeroes the point (like herumi BLS does with theirs). This is not co-factor clearing.

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -8,6 +8,11 @@ import (
 )
 
 func TestPointCompression(t *testing.T) {
+	t.Logf("gen g1: %x", ToCompressedG1(&GenG1))
+	t.Logf("gen g2: %x", ToCompressedG2(&GenG2))
+	t.Logf("gen g1: %x", ToCompressedG1(&ZERO_G1))
+	t.Logf("gen g2: %x", ToCompressedG2(&ZeroG2))
+
 	var x Fr
 	SetFr(&x, "44689111813071777962210527909085028157792767057343609826799812096627770269092")
 	var point G1Point
@@ -17,6 +22,6 @@ func TestPointCompression(t *testing.T) {
 	expected := []byte{134, 87, 163, 76, 148, 138, 55, 228, 171, 85, 80, 116, 242, 13, 169, 151, 167, 6, 219, 183, 108, 254, 214, 99, 184, 231, 210, 201, 39, 69, 184, 188, 105, 194, 22, 32, 9, 57, 220, 81, 82, 164, 97, 236, 201, 116, 2, 83}
 
 	if !bytes.Equal(expected, got) {
-		t.Fatalf("Invalid compression result, %v != %x", got, expected)
+		t.Fatalf("Invalid compression result, %x != %x", got, expected)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,10 @@ require (
 	github.com/herumi/bls-eth-go-binary v0.0.0-20210302070600-dfaa902c7773
 	github.com/holiman/uint256 v1.1.1
 	github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36
+	github.com/supranational/blst v0.3.3-0.20210305121809-81cd381e23cd
 	golang.org/x/sys v0.0.0-20210305034016-7844c3c200c3 // indirect
+)
+
+replace (
+	github.com/supranational/blst v0.3.3-0.20210305121809-81cd381e23cd => ../blst
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,10 @@ github.com/kilic/bls12-381 v0.1.0 h1:encrdjqKMEvabVQ7qYOKu1OvhqpK4s47wDYtNiPtlp4
 github.com/kilic/bls12-381 v0.1.0/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=
 github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36 h1:ac3KEjgHrX671Q7gW6aGmiQcDrYzmwrdq76HElwyewA=
 github.com/kilic/bls12-381 v0.1.1-0.20210208205449-6045b0235e36/go.mod h1:tlkavyke+Ac7h8R3gZIjI5LKBcvMlSWnXNMgT3vZXo8=
+github.com/supranational/blst v0.3.2 h1:66jX8gjJwG738kKvvzeo6DNigXcl+mBFwnhx33TY9FI=
+github.com/supranational/blst v0.3.2/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.3-0.20210305121809-81cd381e23cd h1:4bJnV/19gOnFpVgf7FbpFmoB4/nOvPmtcGZ6BjPtxuk=
+github.com/supranational/blst v0.3.3-0.20210305121809-81cd381e23cd/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1 h1:a/mKvvZr9Jcc8oKfcmgzyp7OwF73JPWsQLvH1z2Kxck=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=


### PR DESCRIPTION
WARNING: work in progress. Known memory leak.

Requires BLST Go bindings patch (the current bindings are very restricted):

```go
type Scalar = C.blst_scalar
type Fr = C.blst_fr

func (s *Scalar) FromFr(a *Fr) {
	C.blst_scalar_from_fr(s, a)
}

func (fr *Fr) FromScalar(a *Scalar) {
	C.blst_fr_from_scalar(fr, a)
}

func (fr *Fr) Add(a *Fr, b *Fr) {
	C.blst_fr_add(fr, a, b)
}

func (fr *Fr) Sub(a *Fr, b *Fr) {
	C.blst_fr_sub(fr, a, b)
}

func (fr *Fr) Mul(a *Fr, b *Fr) {
	C.blst_fr_mul(fr, a, b)
}

func (fr *Fr) Sqr(a *Fr) {
	C.blst_fr_sqr(fr, a)
}

func (fr *Fr) EuclInverse(a *Fr) {
	C.blst_fr_eucl_inverse(fr, a)
}

func (p1 *P1) Negative() {
	C.blst_p1_cneg(p1, true)
}

func (p2 *P2) Negative() {
	C.blst_p2_cneg(p2, true)
}

func (p1 *P1) Add(a *P1, b *P1) {
	C.blst_p1_add(p1, a, b)
}

func (p2 *P2) Add(a *P2, b *P2) {
	C.blst_p2_add(p2, a, b)
}

func (p1 *P1) Mult(a *P1, b *Scalar, nbits uint) {
	C.blst_p1_mult(p1, a, &b.b[0], C.size_t(nbits))
}

func (p2 *P2) Mult(a *P2, b *Scalar, nbits uint) {
	C.blst_p2_mult(p2, a, &b.b[0], C.size_t(nbits))
}

// Tests whether e(a1, a2) == e(b1, b2)
func PairingsVerify(a1 *P1, a2 *P2, b1 *P1, b2 *P2) bool {
	var loop0, loop1, gt_point Fp12
	var aa1, bb1 P1Affine
	var aa2, bb2 P2Affine

	a1neg := *a1
	C.blst_p1_cneg(&a1neg, true)

	C.blst_p1_to_affine(&aa1, &a1neg)
	C.blst_p1_to_affine(&bb1, b1)
	C.blst_p2_to_affine(&aa2, a2)
	C.blst_p2_to_affine(&bb2, b2)

	C.blst_miller_loop(&loop0, &aa2, &aa1)
	C.blst_miller_loop(&loop1, &bb2, &bb1)

	C.blst_fp12_mul(&gt_point, &loop0, &loop1)
	C.blst_final_exp(&gt_point, &gt_point)

	return bool(C.blst_fp12_is_one(&gt_point))
}

func GenP1() *P1 {
	return (*P1)(C.blst_p1_generator())
}

func GenP2() *P2 {
	return (*P2)(C.blst_p2_generator())
}
```