### PR TITLE
reduce degree of poly leaves during tree reduction

### DIFF
--- a/zero_poly.go
+++ b/zero_poly.go
@@ -90,7 +90,9 @@ func (fs *FFTSettings) reduceLeaves(scratch []bls.Fr, dst []bls.Fr, ps [][]bls.F
 	}
 	for i := uint64(0); i < last; i++ {
 		p := ps[i]
-		copy(pPadded[:len(p)], p) // TODO; seems better than iterating all, but assumes the Fr is shallow copyable
+		for j := 0; j < len(p); j++ {
+			bls.CopyFr(&pPadded[j], &p[j])
+		}
 		if err := fs.InplaceFFT(pPadded, pEval, false); err != nil {
 			panic(err)
 		}

--- a/zero_poly_test.go
+++ b/zero_poly_test.go
@@ -48,7 +48,7 @@ func TestFFTSettings_reduceLeaves(t *testing.T) {
 }
 
 func TestFFTSettings_reduceLeaves_parametrized(t *testing.T) {
-	ratios := []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7}
+	ratios := []float64{0.01, 0.1, 0.2, 0.4, 0.5, 0.7, 0.9, 0.99}
 	for scale := uint8(5); scale < 13; scale++ {
 		t.Run(fmt.Sprintf("scale_%d", scale), func(t *testing.T) {
 			for i, ratio := range ratios {
@@ -66,6 +66,9 @@ func testReduceLeaves(scale uint8, missingRatio float64, seed int64, t *testing.
 	rng := rand.New(rand.NewSource(seed))
 	pointCount := uint64(1) << scale
 	missingCount := uint64(int(float64(pointCount) * missingRatio))
+	if missingCount == 0 {
+		return // nothing missing
+	}
 
 	// select the missing points
 	missing := make([]uint64, pointCount, pointCount)


### PR DESCRIPTION
- Update tree reduction code to reduce the leaf lengths more. This should also fix an edge case to enable computation of the zero poly when its length is close to the length of the FFT max width.
- Some code cleanup, add comments/docs
