### PR TITLE
alloc new scratchpad for operations in kilic bls

### DIFF
--- a/bls/bls_kilic.go
+++ b/bls/bls_kilic.go
@@ -11,9 +11,6 @@ import (
 
 var ZERO_G1 G1Point
 
-var curveG1 kbls.G1
-var curveG2 kbls.G2
-
 var GenG1 G1Point
 var GenG2 G2Point
 
@@ -22,12 +19,10 @@ var ZeroG2 G2Point
 
 // Herumi BLS doesn't offer these points to us, so we have to work around it by declaring them ourselves.
 func initG1G2() {
-	curveG1 = *kbls.NewG1()
-	curveG2 = *kbls.NewG2()
-	GenG1 = G1Point(*curveG1.One())
-	GenG2 = G2Point(*curveG2.One())
-	ZeroG1 = G1Point(*curveG1.Zero())
-	ZeroG2 = G2Point(*curveG2.Zero())
+	GenG1 = G1Point(*kbls.NewG1().One())
+	GenG2 = G2Point(*kbls.NewG2().One())
+	ZeroG1 = G1Point(*kbls.NewG1().Zero())
+	ZeroG2 = G2Point(*kbls.NewG2().Zero())
 }
 
 // TODO types file, swap BLS with build args
@@ -45,19 +40,19 @@ func CopyG1(dst *G1Point, v *G1Point) {
 func MulG1(dst *G1Point, a *G1Point, b *Fr) {
 	tmp := (kbls.Fr)(*b) // copy, we want to leave the original in mont-red form
 	(&tmp).FromRed()
-	curveG1.MulScalar((*kbls.PointG1)(dst), (*kbls.PointG1)(a), &tmp)
+	kbls.NewG1().MulScalar((*kbls.PointG1)(dst), (*kbls.PointG1)(a), &tmp)
 }
 
 func AddG1(dst *G1Point, a *G1Point, b *G1Point) {
-	curveG1.Add((*kbls.PointG1)(dst), (*kbls.PointG1)(a), (*kbls.PointG1)(b))
+	kbls.NewG1().Add((*kbls.PointG1)(dst), (*kbls.PointG1)(a), (*kbls.PointG1)(b))
 }
 
 func SubG1(dst *G1Point, a *G1Point, b *G1Point) {
-	curveG1.Sub((*kbls.PointG1)(dst), (*kbls.PointG1)(a), (*kbls.PointG1)(b))
+	kbls.NewG1().Sub((*kbls.PointG1)(dst), (*kbls.PointG1)(a), (*kbls.PointG1)(b))
 }
 
 func StrG1(v *G1Point) string {
-	data := curveG1.ToUncompressed((*kbls.PointG1)(v))
+	data := kbls.NewG1().ToUncompressed((*kbls.PointG1)(v))
 	var a, b big.Int
 	a.SetBytes(data[:48])
 	b.SetBytes(data[48:])
@@ -66,7 +61,7 @@ func StrG1(v *G1Point) string {
 
 func NegG1(dst *G1Point) {
 	// in-place should be safe here (TODO double check)
-	curveG1.Neg((*kbls.PointG1)(dst), (*kbls.PointG1)(dst))
+	kbls.NewG1().Neg((*kbls.PointG1)(dst), (*kbls.PointG1)(dst))
 }
 
 type G2Point kbls.PointG2
@@ -83,24 +78,24 @@ func CopyG2(dst *G2Point, v *G2Point) {
 func MulG2(dst *G2Point, a *G2Point, b *Fr) {
 	tmp := (kbls.Fr)(*b) // copy, we want to leave the original in mont-red form
 	(&tmp).FromRed()
-	curveG2.MulScalar((*kbls.PointG2)(dst), (*kbls.PointG2)(a), &tmp)
+	kbls.NewG2().MulScalar((*kbls.PointG2)(dst), (*kbls.PointG2)(a), &tmp)
 }
 
 func AddG2(dst *G2Point, a *G2Point, b *G2Point) {
-	curveG2.Add((*kbls.PointG2)(dst), (*kbls.PointG2)(a), (*kbls.PointG2)(b))
+	kbls.NewG2().Add((*kbls.PointG2)(dst), (*kbls.PointG2)(a), (*kbls.PointG2)(b))
 }
 
 func SubG2(dst *G2Point, a *G2Point, b *G2Point) {
-	curveG2.Sub((*kbls.PointG2)(dst), (*kbls.PointG2)(a), (*kbls.PointG2)(b))
+	kbls.NewG2().Sub((*kbls.PointG2)(dst), (*kbls.PointG2)(a), (*kbls.PointG2)(b))
 }
 
 func NegG2(dst *G2Point) {
 	// in-place should be safe here (TODO double check)
-	curveG2.Neg((*kbls.PointG2)(dst), (*kbls.PointG2)(dst))
+	kbls.NewG2().Neg((*kbls.PointG2)(dst), (*kbls.PointG2)(dst))
 }
 
 func StrG2(v *G2Point) string {
-	data := curveG2.ToUncompressed((*kbls.PointG2)(v))
+	data := kbls.NewG2().ToUncompressed((*kbls.PointG2)(v))
 	var a, b big.Int
 	a.SetBytes(data[:96])
 	b.SetBytes(data[96:])
@@ -108,15 +103,15 @@ func StrG2(v *G2Point) string {
 }
 
 func EqualG1(a *G1Point, b *G1Point) bool {
-	return curveG1.Equal((*kbls.PointG1)(a), (*kbls.PointG1)(b))
+	return kbls.NewG1().Equal((*kbls.PointG1)(a), (*kbls.PointG1)(b))
 }
 
 func EqualG2(a *G2Point, b *G2Point) bool {
-	return curveG2.Equal((*kbls.PointG2)(a), (*kbls.PointG2)(b))
+	return kbls.NewG2().Equal((*kbls.PointG2)(a), (*kbls.PointG2)(b))
 }
 
 func ToCompressedG1(p *G1Point) []byte {
-	return curveG1.ToCompressed((*kbls.PointG1)(p))
+	return kbls.NewG1().ToCompressed((*kbls.PointG1)(p))
 }
 
 func LinCombG1(numbers []G1Point, factors []Fr) *G1Point {
@@ -135,7 +130,7 @@ func LinCombG1(numbers []G1Point, factors []Fr) *G1Point {
 		v.FromRed()
 		tmpFrs[i] = &v
 	}
-	_, _ = curveG1.MultiExp((*kbls.PointG1)(&out), tmpG1s, tmpFrs)
+	_, _ = kbls.NewG1().MultiExp((*kbls.PointG1)(&out), tmpG1s, tmpFrs)
 	return &out
 }
 


### PR DESCRIPTION
For concurrent usage, we can't reuse the curve instance, and need to allocate a new struct (it contains a scratch pad). Performance does not look much worse.