### PR TITLE
Improve bound on chunklen check

### DIFF
--- a/kzg.go
+++ b/kzg.go
@@ -79,7 +79,7 @@ func NewFK20MultiSettings(ks *KZGSettings, n2 uint64, chunkLen uint64) *FK20Mult
 	if n2 < 2 {
 		panic("extended size is too small")
 	}
-	if chunkLen > n2 {
+	if chunkLen > n2 / 2 {
 		panic("chunk length is too large")
 	}
 	if !bls.IsPowerOfTwo(chunkLen) {


### PR DESCRIPTION
The improved bound ensures that the following does not set `k` to zero, which results in Bad Things:

```
	n := n2 / 2
	k := n / chunkLen
```

Thanks to @Nashatyrev for the downstream fix in [c-kzg](https://github.com/benjaminion/c-kzg).