### PR TITLE
go: update to Go 1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.18.x, 1.19.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/herumi/bls-eth-go-binary v1.28.1
 	github.com/holiman/uint256 v1.1.1
 	github.com/kilic/bls12-381 v0.1.1-0.20220929213557-ca162e8a70f4
-	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
 )
+
+require golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/protolambda/go-kzg
 
-go 1.15
+go 1.18
 
 require (
 	github.com/herumi/bls-eth-go-binary v1.28.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/herumi/bls-eth-go-binary v0.0.0-20210302070600-dfaa902c7773 h1:w4GfJRfUBoA3HgDTs5CWaj94/6e+40BvE6c5qgiOaec=
-github.com/herumi/bls-eth-go-binary v0.0.0-20210302070600-dfaa902c7773/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
 github.com/herumi/bls-eth-go-binary v1.28.1 h1:fcIZ48y5EE9973k05XjE8+P3YiQgjZz4JI/YabAm8KA=
 github.com/herumi/bls-eth-go-binary v1.28.1/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
 github.com/holiman/uint256 v1.1.1 h1:4JywC80b+/hSfljFlEBLHrrh+CIONLDz9NuFl0af4Mw=


### PR DESCRIPTION
Update to Go 1.18. Geth uses Go 1.18 still, and Prysm is on 1.19. This allows newer Go features such as `embed` to work.
