### PR TITLE
Refactor 4844 code to match consensus-specs PR 3093

### DIFF
--- a/bls/globals.go
+++ b/bls/globals.go
@@ -152,20 +152,19 @@ func EvaluatePolyInEvaluationForm(yFr *Fr, poly []Fr, x *Fr, rootsOfUnity []Fr, 
 	MulModFr(yFr, &y, &tmp)
 }
 
-func PolyLinComb(vectors [][]Fr, scalars []Fr) ([]Fr, error) {
+func PolyLinComb(vectors [][]Fr, scalars []Fr, polyDegree int) ([]Fr, error) {
 	l := len(vectors)
 	if l == 0 {
-		return nil, errors.New("input vectors can't be empty")
+		return make([]Fr, polyDegree), nil
 	}
 	if len(scalars) != l {
 		return nil, errors.New("scalars should have same length as input vectors")
 	}
 
-	vlen := len(vectors[0])
-	r := make([]Fr, vlen)
+	r := make([]Fr, polyDegree)
 
 	for j, v := range vectors {
-		if len(v) != vlen {
+		if len(v) != polyDegree {
 			return nil, errors.New("input vectors should all be of identical length")
 		}
 		s := &scalars[j]

--- a/eth/helpers.go
+++ b/eth/helpers.go
@@ -231,6 +231,8 @@ func EvaluatePolynomialInEvaluationForm(poly []bls.Fr, x *bls.Fr) *bls.Fr {
 	return &result
 }
 
+// ComputeChallenges implements compute_challenges from the EIP-4844 consensus spec:
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md#compute_challenges
 func ComputeChallenges(polys Polynomials, comms KZGCommitmentSequence) ([]bls.Fr, *bls.Fr, error) {
 	hash, err := hashPolysComms(polys, comms)
 	if err != nil {

--- a/eth/helpers.go
+++ b/eth/helpers.go
@@ -267,41 +267,26 @@ func hashPolysComms(polys Polynomials, comms KZGCommitmentSequence) ([32]byte, e
 	sha := sha256.New()
 	var hash [32]byte
 
-	_, err := sha.Write([]byte(FIAT_SHAMIR_PROTOCOL_DOMAIN))
-	if err != nil {
-		return hash, err
-	}
+	sha.Write([]byte(FIAT_SHAMIR_PROTOCOL_DOMAIN))
 
 	bytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(bytes, uint64(FieldElementsPerBlob))
-	_, err = sha.Write(bytes)
-	if err != nil {
-		return hash, err
-	}
+	sha.Write(bytes)
 
 	bytes = make([]byte, 8)
 	binary.LittleEndian.PutUint64(bytes, uint64(len(polys)))
-	_, err = sha.Write(bytes)
-	if err != nil {
-		return hash, err
-	}
+	sha.Write(bytes)
 
 	for _, poly := range polys {
 		for _, fe := range poly {
 			b32 := bls.FrTo32(&fe)
-			_, err := sha.Write(b32[:])
-			if err != nil {
-				return hash, err
-			}
+			sha.Write(b32[:])
 		}
 	}
 	l := comms.Len()
 	for i := 0; i < l; i++ {
 		c := comms.At(i)
-		_, err := sha.Write(c[:])
-		if err != nil {
-			return hash, err
-		}
+		sha.Write(c[:])
 	}
 	copy(hash[:], sha.Sum(nil))
 	return hash, nil


### PR DESCRIPTION
PR https://github.com/ethereum/consensus-specs/pull/3093 changes the way fiat-shamir is computed and now allows the cryptography module to handle the case of having no blobs